### PR TITLE
Fix #20125: aws_budgets_budget_action creation error timeout waiting …

### DIFF
--- a/.changelog/21664.txt
+++ b/.changelog/21664.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_budgets_budget_action: Fix aws_budgets_budget_action creation timeout error
+```

--- a/internal/service/budgets/wait.go
+++ b/internal/service/budgets/wait.go
@@ -13,15 +13,7 @@ const (
 
 func waitActionAvailable(conn *budgets.Budgets, accountID, actionID, budgetName string) (*budgets.Action, error) { //nolint:unparam
 	stateConf := &resource.StateChangeConf{
-		Pending: []string{
-			budgets.ActionStatusExecutionInProgress,
-			budgets.ActionStatusStandby,
-		},
-		Target: []string{
-			budgets.ActionStatusExecutionSuccess,
-			budgets.ActionStatusExecutionFailure,
-			budgets.ActionStatusPending,
-		},
+		Target:  budgets.ActionStatus_Values(),
 		Refresh: statusAction(conn, accountID, actionID, budgetName),
 		Timeout: actionAvailableTimeout,
 	}


### PR DESCRIPTION
…for state to become 'EXECUTION_SUCCESS, EXECUTION_FAILURE, PENDING'

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
